### PR TITLE
Fix the RPM Build PipelineRun YAML

### DIFF
--- a/create-build-pipelines/templates/build-rpm-package-pipeline.yaml.j2
+++ b/create-build-pipelines/templates/build-rpm-package-pipeline.yaml.j2
@@ -33,15 +33,13 @@ spec:
       value:
         - localhost
         - linux/arm64
-        - linux/ppc64le
-        - linux/s390x
         - linux/amd64
-    {% if not (build_multi_arch | bool) -%}
+        #- linux/ppc64le
+        #- linux/s390x
     - name: build-architectures
       value:
         - x86_64
         - aarch64
-    {% endif -%}
     - name: ociStorage
       value: quay.io/{{ gh_api.kflux_gh_app.installation.quay_org }}/{{ kflux_data.knflux_tenant_name }}/{{ kflux_data.knflux_comp_name }}:on-pr-{{'{{revision}}'}}
   pipelineRef:

--- a/generate-resource-names/tasks.yaml
+++ b/generate-resource-names/tasks.yaml
@@ -5,11 +5,11 @@
 
 - name: generate Konflux application name lists
   ansible.builtin.set_fact:
-    konflux_application_names: "{% set tmp_app_names = [] %}{% for item in range(starts_from|int, ends_at|int + 1) %}{% set _ = tmp_app_names.append({'key': 'knflux_app_name', 'value': application_name_prefix + (item | string)}) %}{% endfor %}{{ tmp_app_names }}"
+    konflux_application_names: "{% set tmp_app_names = [] %}{% for item in range(starts_from|int, ends_at|int + 1) %}{% if test_scenario == 'rok' %}{% set item = '' %}{% endif %}{% set _ = tmp_app_names.append({'key': 'knflux_app_name', 'value': application_name_prefix + (item | string)}) %}{% endfor %}{{ tmp_app_names }}"
     
 - name: generate Konflux component name lists
   ansible.builtin.set_fact:
-    konflux_component_names: "{% set tmp_comp_names = [] %}{% for item in range(starts_from|int, ends_at|int + 1) %}{% set _ = tmp_comp_names.append({'key': 'knflux_comp_name', 'value': component_name_prefix + (item | string)}) %}{% endfor %}{{ tmp_comp_names }}"
+    konflux_component_names: "{% set tmp_comp_names = [] %}{% for item in range(starts_from|int, ends_at|int + 1) %}{% if test_scenario == 'rok' %}{% set item = '' %}{% endif %}{% set _ = tmp_comp_names.append({'key': 'knflux_comp_name', 'value': component_name_prefix + (item | string)}) %}{% endfor %}{{ tmp_comp_names }}"
 
 - name: generate tenant names for rok scenario
   ansible.builtin.set_fact:


### PR DESCRIPTION
Highlights of the PR
1. Comment IBM archs(s390x, ppc64le) from the `build_platforms` parameter to prevent the Kueue from scheduling the PipelineRuns
2. Generate `konflux_application_names` and `konflux_component_names` without an integer suffix at the end when `test_scenario=rok` is selected