### PR TITLE
fix: pin target-distribution to fedora-41 to avoid Rawhide CDN flakiness

### DIFF
--- a/create-build-pipelines/templates/build-rpm-package-pipeline.yaml.j2
+++ b/create-build-pipelines/templates/build-rpm-package-pipeline.yaml.j2
@@ -40,6 +40,8 @@ spec:
       value:
         - x86_64
         - aarch64
+    - name: target-distribution
+      value: "fedora-41"
     - name: ociStorage
       value: quay.io/{{ gh_api.kflux_gh_app.installation.quay_org }}/{{ kflux_data.knflux_tenant_name }}/{{ kflux_data.knflux_comp_name }}:on-pr-{{'{{revision}}'}}
   pipelineRef:


### PR DESCRIPTION
## Problem

During performance testing with 10 parallel pipeline runs, all pipelines
consistently failed with `RPM deps downloading failed` errors. The root
cause was an HTTP 404 from the Fedora Rawhide CDN:

```
"GET .../Packages/c/curl-8.20.0~rc3-1.fc45.x86_64.rpm HTTP/1.1" 404
ERROR:__main__:Download failed: .../curl-8.20.0~rc3-1.fc45.x86_64.rpm
ERROR:__main__:RPM deps downloading failed
```

The `calculate-deps-x86-64` and `calculate-deps-aarch64` tasks in the
upstream `konflux-ci/rpmbuild-pipeline` use `fedora-rawhide` as the
default `target-distribution`. Rawhide is a rolling release — packages
are superseded continuously, creating a race condition where repodata
references a package filename that the CDN has already replaced.

Two consecutive 10-build batches failed with an identical fingerprint:
- `Tasks Completed: 13 (Failed: 2, Cancelled 0), Skipped: 6`
- 0/10 succeeded in both runs

## Fix

Pin `target-distribution` to `fedora-41` (a stable Fedora release) in
the `PipelineRun` template. This overrides the upstream pipeline default
of `fedora-rawhide` and eliminates CDN race conditions during
high-concurrency performance test runs.

```yaml
- name: target-distribution
  value: "fedora-41"
```

## What is NOT changed

- No changes to the upstream `konflux-ci/rpmbuild-pipeline`
- No changes to task logic, architecture matrix, or any other params
- A separate upstream PR will be submitted to add `retries: 3` to
  `calculate-deps-*` tasks in `konflux-ci/rpmbuild-pipeline`

## References

- KONFLUX-13918: performance test run results and failure analysis

Signed-off-by: Subrata Modak <smodak@redhat.com>
Assisted-by: CursorAI

Made with [Cursor](https://cursor.com)