### PR TITLE
Pin pipelineRef to the latest commit hash of rpmbuild-pipeline

### DIFF
--- a/create-build-pipelines/tasks.yaml
+++ b/create-build-pipelines/tasks.yaml
@@ -44,6 +44,15 @@
     path: "../{{ git_workspace_dir }}/{{ source_repo_name }}/.tekton"
     state: directory
 
+- name: Retrieve the latest commit hash from rpmbuild-pipeline main
+  ansible.builtin.shell: |
+    git ls-remote {{ rpmbuild_pipeline_url }} refs/heads/main | awk '{print $1}'
+  register: git_ls_remote_command_status
+
+- name: Set commit hash to use in the build pipelines for revision parameter
+  ansible.builtin.set_fact:
+    rpmbuild_pipeline_latest_revision: "{{ git_ls_remote_command_status.stdout }}"
+
 - name: render build pipeline templates
   ansible.builtin.template:
     src: ../create-build-pipelines/templates/{{ component_overlay }}/build-pipeline.yaml.j2

--- a/create-build-pipelines/templates/package/build-pipeline.yaml.j2
+++ b/create-build-pipelines/templates/package/build-pipeline.yaml.j2
@@ -42,13 +42,17 @@ spec:
         - aarch64
     - name: ociStorage
       value: quay.io/{{ gh_api.kflux_gh_app.installation.quay_org }}/{{ kflux_data.knflux_tenant_name }}/{{ kflux_data.knflux_comp_name }}:on-pr-{{'{{revision}}'}}
+    - name: self-ref-url
+      value: "{{ rpmbuild_pipeline_url }}"
+    - name: self-ref-revision
+      value: "{{ rpmbuild_pipeline_latest_revision }}"
   pipelineRef:
     resolver: git
     params:
       - name: url
-        value: https://github.com/konflux-ci/rpmbuild-pipeline.git 
+        value: "{{ rpmbuild_pipeline_url }}"
       - name: revision
-        value: "main"
+        value: "{{ rpmbuild_pipeline_latest_revision }}"
       - name: pathInRepo
         value: pipeline/build-rpm-package.yaml
   workspaces:

--- a/vars/konflux_repo_app_component_config.yml
+++ b/vars/konflux_repo_app_component_config.yml
@@ -47,6 +47,9 @@ source_git_repo: "git@github.com:mcharanrm/example-fedora-konflux-libecpg-perf-f
 # Temporary workspace/directory for generating build pipelines, committing it and creating pull requests
 git_workspace_dir: "build-pipelines-workspace"
 
+# Path to RPM build pipeline
+rpmbuild_pipeline_url: "https://github.com/mcharanrm/rpmbuild-pipeline.git"
+
 # Path to read GitHub PATs
 github_pat_file: "{{ ansible_facts['user_dir'] + '/.github-pat.json' }}"
 


### PR DESCRIPTION
Setting the revision value to a commit SHA while using the Git Resolver improves stability when applied consistently across all references. This improves scalability because using a commit hash allows Tekton to cache resolved resources, since the revision becomes immutable and identical requests can reuse previously fetched pipeline and task definitions instead of repeatedly cloning and resolving Git content. 